### PR TITLE
C++ element definitions now support any kind of arithmetic types

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Vue Special Syntax
 - `v-if/v-else-if/v-else`.
 - `v-for` (does not support int index e.g.: `value, key, index`).
 - `v-on`.
-  - `v-on:(click:mousedown|mouseup|mouseover|mouseout)[.[ctrl|alt|meta|shift|exact]]`.
+  - `v-on:(click|mousedown|mouseup|mouseover|mouseout)[.[ctrl|alt|meta|shift|exact]]`.
   - `v-on:(keyup|keydown|keypress)[.][<key_code>]`.
   - `v-on:change`.
 - Attributes starting with `:` are treated as `v-bind:...`.

--- a/src/imvue.cpp
+++ b/src/imvue.cpp
@@ -257,32 +257,6 @@ namespace ImVue {
       return;
     }
 
-    if(!mConfigured) {
-      // register some built-in element types
-      mCtx->factory->element<Document>("template");
-      mCtx->factory->element<Element>("__element__")
-        .handler<MouseEventHandler>("click")
-        .handler<MouseEventHandler>("mousedown")
-        .handler<MouseEventHandler>("mouseup")
-        .handler<MouseEventHandler>("mouseover")
-        .handler<MouseEventHandler>("mouseout")
-        .handler<MouseEventHandler>("mouseout")
-        .handler<ChangeEventHandler>("change")
-        .handler<KeyboardEventHandler>("keydown")
-        .handler<KeyboardEventHandler>("keyup")
-        .handler<KeyboardEventHandler>("keypress")
-        .attribute("id", &Element::id)
-        .attribute("key", &Element::key)
-        .attribute("ref", &Element::ref);
-
-      mCtx->factory->element<Slot>("slot");
-
-      mCtx->factory->element<SvgImage>("svg-image")
-        .attribute("size", &SvgImage::size)
-        .attribute("src", &SvgImage::src, true)
-        .attribute("tint-col", &SvgImage::tint_col);
-    }
-
     mScriptState = mCtx->script;
 
     std::stringstream ss;

--- a/src/imvue_generated.h
+++ b/src/imvue_generated.h
@@ -4,6 +4,7 @@
 #define __IMVUE_CONFIG_H__
 
 #include "imgui.h"
+#include "imvue.h"
 #include "imvue_element.h"
 #include "imvue_errors.h"
 
@@ -2164,6 +2165,24 @@ namespace ImVue {
     factory.element<CollapsingHeader>("collapsing-header")
       .attribute("label", &CollapsingHeader::label)
       .attribute("flags", &CollapsingHeader::flags);
+
+      // register some built-in element types
+    factory.element<Document>("template");
+    factory.element<Element>("__element__")
+        .handler<MouseEventHandler>("click")
+        .handler<MouseEventHandler>("mousedown")
+        .handler<MouseEventHandler>("mouseup")
+        .handler<MouseEventHandler>("mouseover")
+        .handler<MouseEventHandler>("mouseout")
+        .handler<ChangeEventHandler>("change")
+        .handler<KeyboardEventHandler>("keydown")
+        .handler<KeyboardEventHandler>("keyup")
+        .handler<KeyboardEventHandler>("keypress")
+        .attribute("id", &Element::id)
+        .attribute("key", &Element::key)
+        .attribute("ref", &Element::ref);
+
+    factory.element<Slot>("slot");
     return res;
   }
 }

--- a/src/imvue_script.cpp
+++ b/src/imvue_script.cpp
@@ -96,7 +96,7 @@ namespace ImVue {
         }
         break;
       case ObjectType::INTEGER:
-        mObject->setInteger(*reinterpret_cast<unsigned long*>(value));
+        mObject->setInteger(*reinterpret_cast<long*>(value));
         break;
       case ObjectType::NUMBER:
         mObject->setNumber(*reinterpret_cast<double*>(value));
@@ -149,22 +149,6 @@ namespace ImVue {
   float Object::as<float>() const
   {
     return (float)as<double>();
-  }
-
-  template<>
-  int Object::as<int>() const
-  {
-    if(!mObject) {
-      return 0;
-    }
-
-    return mObject->readInt();
-  }
-
-  template<>
-  size_t Object::as<size_t>() const
-  {
-    return (size_t)as<int>();
   }
 
   void ScriptState::ReactListener::trigger()

--- a/src/imvue_script.h
+++ b/src/imvue_script.h
@@ -119,7 +119,7 @@ namespace ImVue {
       /**
        * Read value as integer
        */
-      virtual int readInt() = 0;
+      virtual long readInt() = 0;
 
       /**
        * Read value as string
@@ -138,7 +138,7 @@ namespace ImVue {
 
       // mandatory setters
       virtual void setObject(Object& value) = 0;
-      virtual void setInteger(unsigned long value) = 0;
+      virtual void setInteger(long value) = 0;
       virtual void setNumber(double value) = 0;
       virtual void setString(const char* value) = 0;
       virtual void setBool(bool value) = 0;
@@ -183,6 +183,22 @@ namespace ImVue {
 
       template<typename C>
       C as() const {
+        return as<C>(std::is_integral<C>());
+      }
+
+      template<typename C>
+      C as(std::true_type) const
+      {
+        if(!mObject) {
+          return 0;
+        }
+
+        return (C)mObject->readInt();
+      }
+
+      template<typename C>
+      C as(std::false_type) const
+      {
         IMVUE_EXCEPTION(ScriptError, "unsupported cast");
         return C{};
       }
@@ -207,12 +223,6 @@ namespace ImVue {
 
   template<>
   float Object::as<float>() const;
-
-  template<>
-  int Object::as<int>() const;
-
-  template<>
-  size_t Object::as<size_t>() const;
 
   class ObjectIterator {
     public:

--- a/src/lua/script.cpp
+++ b/src/lua/script.cpp
@@ -216,7 +216,7 @@ extern "C" {
 
       virtual void keys(ObjectKeys& res);
 
-      virtual int readInt() {
+      virtual long readInt() {
         StackGuard g(mLuaState);
         unwrap();
         return lua_tointeger(mLuaState, -1);
@@ -251,7 +251,7 @@ extern "C" {
         assign();
       }
 
-      virtual void setInteger(unsigned long value)
+      virtual void setInteger(long value)
       {
         lua_pushinteger(mLuaState, value);
         assign();

--- a/tests/unit/imvue_tests.cpp
+++ b/tests/unit/imvue_tests.cpp
@@ -695,7 +695,7 @@ TEST(TestGeneratedElement, Separator)
 const char* testDocumentVSliderFloat =
 "<template>"
   "<window name=\"test\">"
-    "<v-slider-float v=\"None\">test</v-slider-float>"
+    "<v-slider-float v=\"0.0\">test</v-slider-float>"
   "</window>"
 "</template>";
 
@@ -1020,7 +1020,7 @@ TEST(TestGeneratedElement, ArrowButton)
 const char* testDocumentSliderFloat =
 "<template>"
   "<window name=\"test\">"
-    "<slider-float v=\"None\">test</slider-float>"
+    "<slider-float v=\"0.0\">test</slider-float>"
   "</window>"
 "</template>";
 

--- a/tests/unit/parser.cpp
+++ b/tests/unit/parser.cpp
@@ -91,3 +91,319 @@ TEST(DocumentParser, DocumentCopy)
   ImVue::Document duplicate = document;
   renderDocument(duplicate);
 }
+
+#if defined(WITH_LUA)
+#include "lua/script.h"
+extern "C" {
+  #include <lua.h>
+  #include <lualib.h>
+  #include <lauxlib.h>
+}
+#endif
+
+class Validator : public ImVue::Element
+{
+  public:
+    Validator()
+      : arrVariadic(nullptr)
+      , ch(nullptr)
+    {
+    }
+
+    ~Validator()
+    {
+      if(ch) ImGui::MemFree(ch);
+      if(arrVariadic) ImGui::MemFree(arrVariadic);
+    }
+
+    void renderBody()
+    {
+    }
+
+    bool flag;
+    float fl;
+    double dbl;
+    ImU16 u16;
+    ImU32 u32;
+    ImU64 u64;
+    short i16;
+    int i32;
+    long i64;
+    ImVec2 vec2;
+    ImVec4 vec4;
+    char* ch;
+    int arrFixed[3];
+    int* arrVariadic;
+#if defined(WITH_LUA)
+    ImVue::Object object;
+#endif
+};
+
+typedef std::tuple<const char*, bool> ReadTypesParam;
+
+class ReadTypesTest : public ::testing::Test, public testing::WithParamInterface<ReadTypesParam> {
+#if defined(WITH_LUA)
+  protected:
+    void SetUp() override {
+      L = luaL_newstate();
+      luaL_openlibs(L);
+      ImVue::registerBindings(L);
+    }
+
+    void TearDown() override {
+      lua_close(L);
+    }
+
+    lua_State* L;
+#endif
+};
+
+/**
+ * Test parsing various types
+ */
+TEST_P(ReadTypesTest, ParseTypes)
+{
+  ImVue::ElementFactory* factory = ImVue::createElementFactory();
+  factory->element<Validator>("validator")
+    .attribute("flag", &Validator::flag, true)
+    .attribute("float", &Validator::fl, true)
+    .attribute("double", &Validator::dbl, true)
+    .attribute("u16", &Validator::u16, true)
+    .attribute("u32", &Validator::u32, true)
+    .attribute("u64", &Validator::u64, true)
+    .attribute("i16", &Validator::i16, true)
+    .attribute("i32", &Validator::i32, true)
+    .attribute("i64", &Validator::i64, true)
+    .attribute("ch", &Validator::ch, true)
+    .attribute("vec2", &Validator::vec2, true)
+    .attribute("vec4", &Validator::vec4, true)
+    .attribute("arr-fixed", &Validator::arrFixed, true)
+    .attribute("arr-variadic", &Validator::arrVariadic, true)
+#if defined(WITH_LUA)
+    .attribute("object", &Validator::object)
+#endif
+    ;
+
+  ImVue::Context* ctx = ImVue::createContext(
+      factory
+#if defined(WITH_LUA)
+      ,
+      new ImVue::LuaScriptState(L)
+#endif
+  );
+  ImVue::Document document(ctx);
+  const char* body = NULL;
+  bool checkObject;
+  std::tie(body, checkObject) = GetParam();
+  document.parse(body);
+  renderDocument(document);
+  ImVector<Validator*> children = document.getChildren<Validator>("validator", true);
+  Validator* el = children[0];
+  EXPECT_EQ(el->u16, 65535);
+  EXPECT_EQ(el->u32, 65536);
+  EXPECT_EQ(el->u64, 4294967295);
+  EXPECT_EQ(el->i16, -32765);
+  EXPECT_EQ(el->i32, -65536);
+  EXPECT_EQ(el->i64, -1073741823);
+  EXPECT_FLOAT_EQ(el->vec2.x, 2);
+  EXPECT_FLOAT_EQ(el->vec2.y, 2);
+
+  EXPECT_FLOAT_EQ(el->vec4.x, 2);
+  EXPECT_FLOAT_EQ(el->vec4.y, 2);
+  EXPECT_FLOAT_EQ(el->vec4.z, 2);
+  EXPECT_FLOAT_EQ(el->vec4.w, 2);
+
+  EXPECT_FLOAT_EQ(el->fl, 0.1);
+  EXPECT_DOUBLE_EQ(el->dbl, 0.05);
+
+  EXPECT_STREQ(el->ch, "hello");
+  for(size_t i = 0; i < 3; ++i) {
+    EXPECT_EQ(el->arrFixed[i], i + 1);
+  }
+
+  ASSERT_NE(el->arrVariadic, nullptr);
+  for(size_t i = 0; i < 5; ++i) {
+    EXPECT_EQ(el->arrVariadic[i], i + 1);
+  }
+#if defined(WITH_LUA)
+  if(checkObject) {
+    ASSERT_NE(el->object.type(), ImVue::ObjectType::NIL);
+    EXPECT_STREQ(el->object["it"].as<ImString>(), "works");
+  }
+#endif
+}
+
+const char* dataStatic = "<template>"
+  "<validator "
+    "flag='true' "
+    "u16='65535' u32='65536' u64='4294967295' "
+    "i16='-32765' i32='-65536' i64='-1073741823' "
+    "vec2='{2,2}' vec4='{2,2,2,2}' "
+    "float='0.1' double='0.05' "
+    "ch='hello' "
+    "arr-fixed='{1,2,3}' arr-variadic='{1,2,3,4,5}' "
+    "/>"
+"</template>";
+
+const char* dataBind = "<template>"
+  "<validator "
+    ":flag='true' "
+    ":u16='65535' :u32='65536' :u64='4294967295' "
+    ":i16='-32765' :i32='-65536' :i64='-1073741823' "
+    ":vec2='{2,2}' :vec4='{2,2,2,2}' "
+    ":ch='\"hello\"' "
+    ":arr-fixed='{1,2,3}' arr-variadic='{1,2,3,4,5}' "
+    ":float='0.1' :double='0.05' "
+    ":object='{it=\"works\"}'"
+    "/>"
+"</template>"
+"<script>"
+  "return ImVue.new({})"
+"</script>";
+
+INSTANTIATE_TEST_CASE_P(
+  ParseTypes,
+  ReadTypesTest,
+  ::testing::Values(
+    std::make_tuple(dataStatic, false)
+#if defined(WITH_LUA)
+    ,
+    std::make_tuple(dataBind, true)
+#endif
+  )
+);
+
+/**
+ * Test reading various types
+ * low level test
+ */
+TEST(DocumentParser, StaticArrayReader) {
+  // reading array of length 1
+  {
+    float vals[1] = {0.0f};
+    EXPECT_TRUE(ImVue::detail::read("{1.2}", &vals));
+    EXPECT_FLOAT_EQ(vals[0], 1.2);
+  }
+  // reading array of length 2
+  {
+    double vals[2] = {0.0};
+    EXPECT_TRUE(ImVue::detail::read("{1.2, 2.4}", &vals));
+    EXPECT_DOUBLE_EQ(vals[0], 1.2);
+    EXPECT_DOUBLE_EQ(vals[1], 2.4);
+  }
+  // various correct inputs with traling spaces/different bracket types
+  {
+    const char* cases[4] = {
+      "  \t\n{1.2, 2.4}\n\t",
+      "[1.2, 2.4]",
+      "(1.2, 2.4)",
+      "1.2, 2.4"
+    };
+
+    for (int i = 0; i < 4; ++i) {
+      double vals[2] = {0.0};
+      EXPECT_TRUE(ImVue::detail::read(cases[i], &vals));
+      EXPECT_DOUBLE_EQ(vals[0], 1.2);
+      EXPECT_DOUBLE_EQ(vals[1], 2.4);
+    }
+  }
+  // various incorrect inputs
+  {
+    const char* cases[4] = {
+      "{[1.2, 2.4]",
+      "(1.2, 2.4}",
+      "{}",
+      " "
+    };
+
+    for (int i = 0; i < 4; ++i) {
+      double vals[2] = {0.0};
+      EXPECT_FALSE(ImVue::detail::read(cases[i], &vals));
+      EXPECT_DOUBLE_EQ(vals[0], 0.0);
+      EXPECT_DOUBLE_EQ(vals[1], 0.0);
+    }
+  }
+  // variable array length
+  {
+    int* vars = nullptr;
+    EXPECT_TRUE(ImVue::detail::read("{1,2,3,4,5,6}", &vars));
+    EXPECT_NE(vars, nullptr);
+    for (int i = 0; i < 6; ++i) {
+      EXPECT_EQ(vars[i], i+1);
+    }
+    // re-read to verify proper memory usage
+    EXPECT_TRUE(ImVue::detail::read("{1,2,3,4,5,6}", &vars));
+    EXPECT_NE(vars, nullptr);
+    for (int i = 0; i < 6; ++i) {
+      EXPECT_EQ(vars[i], i+1);
+    }
+    ImGui::MemFree(vars);
+  }
+}
+
+class BaseRequiredValidator : public ImVue::Element
+{
+  public:
+    void renderBody()
+    {
+    }
+
+    int base;
+};
+
+class RequiredValidator : public BaseRequiredValidator
+{
+  public:
+    int value;
+};
+/**
+ * Test required fields validation
+ */
+TEST(DocumentParser, RequiredPropsValidation) {
+
+  ImVue::ElementFactory* factory = ImVue::createElementFactory();
+  factory->element<BaseRequiredValidator>("base-validator")
+    .attribute("base", &BaseRequiredValidator::base, true);
+
+  factory->element<RequiredValidator>("validator")
+    .inherits("base-validator")
+    .attribute("value", &RequiredValidator::value, true);
+
+  ImVue::Context* ctx = ImVue::createContext(
+      factory
+  );
+
+  ImVue::Document document(ctx);
+  {
+    const char* body = "<template><validator value='crashme'/></template>";
+
+    bool gotError = false;
+    ASSERT_THROW(document.parse(body), ImVue::ElementError);
+    renderDocument(document);
+  }
+
+  {
+    const char* body = "<template><validator value='1' base='?'/></template>";
+
+    bool gotError = false;
+    ASSERT_THROW(document.parse(body), ImVue::ElementError);
+    renderDocument(document);
+  }
+
+  {
+    const char* body = "<template><validator/></template>";
+
+    bool gotError = false;
+    ASSERT_THROW(document.parse(body), ImVue::ElementError);
+    renderDocument(document);
+  }
+
+  // now pass
+  {
+    const char* body = "<template><validator value='1' base='3'/></template>";
+
+    bool gotError = false;
+    document.parse(body);
+    renderDocument(document);
+  }
+}

--- a/tools/config.yaml
+++ b/tools/config.yaml
@@ -157,12 +157,14 @@ elements_rules:
       - v
     test_values:
       p_data: 1
+      v: 0.0
   SliderFloat:
     required_fields:
       - label
       - v
     test_values:
       p_data: 1
+      v: 0.0
 
 # test generator config section
 test_values_by_type:

--- a/tools/templates/imvue_generated.h.j2
+++ b/tools/templates/imvue_generated.h.j2
@@ -15,6 +15,7 @@
 #define __IMVUE_CONFIG_H__
 
 #include "imgui.h"
+#include "imvue.h"
 #include "imvue_element.h"
 #include "imvue_errors.h"
 
@@ -112,6 +113,24 @@ namespace ImVue {
     factory.element<CollapsingHeader>("collapsing-header")
       .attribute("label", &CollapsingHeader::label)
       .attribute("flags", &CollapsingHeader::flags);
+
+      // register some built-in element types
+    factory.element<Document>("template");
+    factory.element<Element>("__element__")
+        .handler<MouseEventHandler>("click")
+        .handler<MouseEventHandler>("mousedown")
+        .handler<MouseEventHandler>("mouseup")
+        .handler<MouseEventHandler>("mouseover")
+        .handler<MouseEventHandler>("mouseout")
+        .handler<ChangeEventHandler>("change")
+        .handler<KeyboardEventHandler>("keydown")
+        .handler<KeyboardEventHandler>("keyup")
+        .handler<KeyboardEventHandler>("keypress")
+        .attribute("id", &Element::id)
+        .attribute("key", &Element::key)
+        .attribute("ref", &Element::ref);
+
+    factory.element<Slot>("slot");
     return res;
   }
 }


### PR DESCRIPTION
In scope of: https://github.com/Unix4ever/imvue/issues/9
Updated static list parser.
Now it can have same syntax as any script may have. E.g.:
- `{1,2,3}` lua style list;
- `[1,2,3]` js style list;
- `(a,b,c)` python tuple;

Old syntax without brackets is also supported.

Additionally fixed several issues in tests, improved test coverage,
added tests for parser, field validation.

Found a problem with `required` field not working for fields that are
missing from the xml node (only if field parsing failed we were getting
an error).
